### PR TITLE
feat(frame): add frame components

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "../index.css";
 import Providers from "@/components/providers";
-import Header from "@/components/header";
+import { ScreenFrame } from "@/components/os/frame";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -30,10 +30,9 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <Providers>
-          <div className="grid grid-rows-[auto_1fr] h-svh">
-            <Header />
+          <ScreenFrame>
             {children}
-          </div>
+          </ScreenFrame>
         </Providers>
       </body>
     </html>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,46 +1,7 @@
-"use client"
-import { useQuery } from "@tanstack/react-query";
-import { trpc } from "@/utils/trpc";
-
-const TITLE_TEXT = `
- ██████╗ ███████╗████████╗████████╗███████╗██████╗
- ██╔══██╗██╔════╝╚══██╔══╝╚══██╔══╝██╔════╝██╔══██╗
- ██████╔╝█████╗     ██║      ██║   █████╗  ██████╔╝
- ██╔══██╗██╔══╝     ██║      ██║   ██╔══╝  ██╔══██╗
- ██████╔╝███████╗   ██║      ██║   ███████╗██║  ██║
- ╚═════╝ ╚══════╝   ╚═╝      ╚═╝   ╚══════╝╚═╝  ╚═╝
-
- ████████╗    ███████╗████████╗ █████╗  ██████╗██╗  ██╗
- ╚══██╔══╝    ██╔════╝╚══██╔══╝██╔══██╗██╔════╝██║ ██╔╝
-    ██║       ███████╗   ██║   ███████║██║     █████╔╝
-    ██║       ╚════██║   ██║   ██╔══██║██║     ██╔═██╗
-    ██║       ███████║   ██║   ██║  ██║╚██████╗██║  ██╗
-    ╚═╝       ╚══════╝   ╚═╝   ╚═╝  ╚═╝ ╚═════╝╚═╝  ╚═╝
- `;
-
 export default function Home() {
-  const healthCheck = useQuery(trpc.healthCheck.queryOptions());
-  
   return (
-    <div className="container mx-auto max-w-3xl px-4 py-2">
-      <pre className="overflow-x-auto font-mono text-sm">{TITLE_TEXT}</pre>
-      <div className="grid gap-6">
-        <section className="rounded-lg border p-4">
-          <h2 className="mb-2 font-medium">API Status</h2>
-            <div className="flex items-center gap-2">
-              <div
-                className={`h-2 w-2 rounded-full ${healthCheck.data ? "bg-green-500" : "bg-red-500"}`}
-              />
-              <span className="text-sm text-muted-foreground">
-                {healthCheck.isLoading
-                  ? "Checking..."
-                  : healthCheck.data
-                    ? "Connected"
-                    : "Disconnected"}
-              </span>
-            </div>
-        </section>
-      </div>
-    </div>
+    <main className="flex h-full w-full items-center justify-center">
+      <p className="text-white">Welcome to PurityOS</p>
+    </main>
   );
 }

--- a/apps/web/src/components/index.ts
+++ b/apps/web/src/components/index.ts
@@ -1,0 +1,1 @@
+export * from "./os/frame"; 

--- a/apps/web/src/components/os/appbar/AppBar.tsx
+++ b/apps/web/src/components/os/appbar/AppBar.tsx
@@ -1,0 +1,12 @@
+"use client";
+
+export default function AppBar({ accent = "#8f8f8f" }: { accent?: string }) {
+  return (
+    <div
+      className="fixed bottom-0 left-0 right-0 z-40 flex h-[45px] items-center border-t"
+      style={{ backgroundColor: accent }}
+    >
+      {/* TODO: Build full AppBar */}
+    </div>
+  );
+} 

--- a/apps/web/src/components/os/frame/BrandingLabel.tsx
+++ b/apps/web/src/components/os/frame/BrandingLabel.tsx
@@ -1,0 +1,28 @@
+"use client";
+
+import { motion } from "framer-motion";
+
+export function BrandingLabel() {
+  return (
+    <motion.span
+      className="absolute left-1/2 top-0 z-35 select-none font-bold"
+      style={{
+        transform: "translateX(-50%)",
+        height: 50,
+        display: "flex",
+        alignItems: "center",
+        color: "#ffffff",
+        textShadow: "1px 1px 0 #000",
+        fontSize: 14,
+      }}
+      aria-hidden="true"
+      initial={{ opacity: 0 }}
+      animate={{ opacity: 1 }}
+      transition={{ duration: 0.25 }}
+    >
+      PurityOS
+    </motion.span>
+  );
+}
+
+export default BrandingLabel; 

--- a/apps/web/src/components/os/frame/DirectoryLabel.tsx
+++ b/apps/web/src/components/os/frame/DirectoryLabel.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { motion, AnimatePresence } from "framer-motion";
+
+interface DirectoryLabelProps {
+  path?: string;
+}
+
+export function DirectoryLabel({ path }: DirectoryLabelProps) {
+  return (
+    <AnimatePresence>
+      {path && (
+        <motion.span
+          key={path}
+          className="absolute left-1/2 top-0 z-35 pointer-events-none font-mono"
+          style={{
+            transform: "translateX(-50%)",
+            height: 50,
+            display: "flex",
+            alignItems: "flex-end",
+            paddingBottom: 4,
+            color: "#c0c0c0",
+            textShadow: "1px 1px 0 #000",
+            fontSize: 12,
+          }}
+          aria-live="polite"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.15 }}
+        >
+          {path}
+        </motion.span>
+      )}
+    </AnimatePresence>
+  );
+}
+
+export default DirectoryLabel; 

--- a/apps/web/src/components/os/frame/OuterBezel.tsx
+++ b/apps/web/src/components/os/frame/OuterBezel.tsx
@@ -1,0 +1,41 @@
+"use client";
+
+import { motion } from "framer-motion";
+import { cn } from "@/lib/utils";
+
+const NOISE_SVG =
+  "data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNCIgaGVpZ2h0PSI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxyZWN0IHdpZHRoPSIxIiBoZWlnaHQ9IjEiIGZpbGw9IiNmZmYiLz48cmVjdCB4PSIxIiB5PSIyIiB3aWR0aD0iMSIgaGVpZ2h0PSIxIiBmaWxsPSIjZmZmIi8+PC9zdmc+";
+
+interface OuterBezelProps {
+  className?: string;
+}
+
+export function OuterBezel({ className }: OuterBezelProps) {
+  return (
+    <motion.div
+      role="presentation"
+      initial={{ opacity: 0, scale: 0.98 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={{ duration: 0.25, ease: "easeOut" }}
+      className={cn(
+        "fixed inset-0 pointer-events-none z-30",
+        "bg-[color:var(--frame)] shadow-[0_0_0_3px_var(--shadow)]",
+        "after:absolute after:inset-0 after:[box-shadow:inset_0_0_0_1px_var(--highlight)]",
+        className,
+      )}
+      style={{
+        "--frame": "#8f8f8f",
+        "--highlight": "#ffffff",
+        "--shadow": "#000000",
+      } as React.CSSProperties}
+    >
+      {/* subtle noise */}
+      <div
+        className="absolute inset-0 opacity-5"
+        style={{ backgroundImage: `url(${NOISE_SVG})`, backgroundRepeat: "repeat" }}
+      />
+    </motion.div>
+  );
+}
+
+export default OuterBezel; 

--- a/apps/web/src/components/os/frame/ScreenFrame.tsx
+++ b/apps/web/src/components/os/frame/ScreenFrame.tsx
@@ -1,0 +1,35 @@
+"use client";
+
+import { OuterBezel } from "./OuterBezel";
+import { BrandingLabel } from "./BrandingLabel";
+import { DirectoryLabel } from "./DirectoryLabel";
+import dynamic from "next/dynamic";
+
+// Lazy-load AppBar to avoid SSR mismatch before its full implementation
+const AppBar = dynamic(() => import("../appbar/AppBar"), { ssr: false });
+
+export interface ScreenFrameProps {
+  className?: string;
+  withAppBar?: boolean;
+  path?: string;
+  children: React.ReactNode;
+}
+
+export function ScreenFrame({
+  children,
+  withAppBar = true,
+  className,
+  path,
+}: ScreenFrameProps) {
+  return (
+    <div className="relative h-svh w-svw overflow-hidden bg-black">
+      <OuterBezel className={className} />
+      <BrandingLabel />
+      <DirectoryLabel path={path} />
+      <div className="relative z-40 size-full overflow-hidden">{children}</div>
+      {withAppBar && <AppBar accent="#8f8f8f" />}
+    </div>
+  );
+}
+
+export default ScreenFrame; 

--- a/apps/web/src/components/os/frame/index.ts
+++ b/apps/web/src/components/os/frame/index.ts
@@ -1,0 +1,2 @@
+export { ScreenFrame } from "./ScreenFrame";
+export type { ScreenFrameProps } from "./ScreenFrame"; 

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -1,7 +1,11 @@
 {
   "compilerOptions": {
     "target": "ES2017",
-    "lib": ["dom", "dom.iterable", "esnext"],
+    "lib": [
+      "dom",
+      "dom.iterable",
+      "esnext"
+    ],
     "allowJs": true,
     "skipLibCheck": true,
     "strict": true,
@@ -20,12 +24,24 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["./next-env.d.ts", "./**/*.ts", "./**/*.tsx", "./.next/types/**/*.ts"],
-  "exclude": ["./node_modules"],
-  "references": [{
-    "path": "../server"
-  }]
+  "include": [
+    "./**/*.ts",
+    "./**/*.tsx",
+    "./.next/types/**/*.ts",
+    "./next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "./node_modules"
+  ],
+  "references": [
+    {
+      "path": "../server"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Introduced foundational CRT frame components including:
- `OuterBezel`
- `ScreenFrame`
- `DirectoryLabel`
- `BrandingLabel`
- `AppBar`

These establish the outer container and top UI bar for PurityOS.

## Context

This is part of the UI groundwork for all `.sh`-style environments.

## Next Steps

- Hook into window manager
- Add frame scaling support
- Style for dark/light modes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a visually enhanced screen frame with branding and directory labels, animated transitions, and a decorative outer bezel.
  * Added a customizable bottom app bar to the interface.

* **Refactor**
  * Simplified the main layout and home page for a cleaner, static welcome experience.
  * Centralized and streamlined component exports for easier access.

* **Style**
  * Updated configuration file formatting for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->